### PR TITLE
feat: expose search path in preferences

### DIFF
--- a/actionlint.novaextension/extension.json
+++ b/actionlint.novaextension/extension.json
@@ -9,13 +9,24 @@
   "version": "1.0",
   "categories": ["issues"],
   "main": "main.js",
-
   "activationEvents": [
     "onLanguage:yaml",
     "onWorkspaceContains:.github/workflows/*"
   ],
-
   "entitlements": {
     "process": true
-  }
+  },
+  "config": [
+    {
+      "key": "actionlint.searchpath",
+      "title": "Search path",
+      "description": "Workspace folders to look in when invoking Actionlint. If you store files outside of the default (.github/workflows), add those paths here.",
+      "type": "pathArray",
+      "allowFiles": true,
+      "allowFolders": true,
+      "relative": true,
+      "required": true,
+      "default": [".github/workflows"]
+    }
+  ]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,16 @@ type ActionlintOutput = {
 
 class IssuesProvider {
   provideIssues(editor: TextEditor): AssistantArray<Issue> {
-    console.info("validating:", editor.document.uri);
+    const relativePath: string = editor.document.path.replace(
+      nova.workspace.path,
+      ""
+    );
+    console.info(`Evaluating: ${editor.document.uri}`);
+    const path: string[] = nova.config.get("actionlint.searchpath", "array");
+    if (!path.find((element) => relativePath.includes(element))) {
+      console.info(`Skipping: ${relativePath} - doesn't match config path`);
+      return;
+    }
 
     const documentLength = editor.document.length;
     const content = editor.document.getTextInRange(


### PR DESCRIPTION
Allow users to choose what to process based on file/directory path. Useful to avoid files like `pnpm-lock.yaml` being processed. Should you store github actions in other folders than the default (`.github/workflows`), add them to the search path to see them processed.

Fixes: https://github.com/jbergstroem/nova-actionlint/issues/2